### PR TITLE
group and auto expand report

### DIFF
--- a/lib/buildkite/rspec/formatter.rb
+++ b/lib/buildkite/rspec/formatter.rb
@@ -38,6 +38,11 @@ module Buildkite
         output.puts "--- –––"
       end
 
+      def dump_summary(summary)
+        output.puts "+++ Summary"
+        super
+      end
+
       private def prefix
         return "" if @group_level == 0
         "#{'  ' * [@group_level - 1, 0].max}⊢–"


### PR DESCRIPTION
Thanks for the formatter :)

I often find it handy to see the concise summary at the end of spec runs (especially for the failure case):

![image](https://user-images.githubusercontent.com/1468141/29302113-04a20c7e-81b4-11e7-9720-6a9dc2e98410.png)

![image](https://user-images.githubusercontent.com/1468141/29302233-e6b9d506-81b4-11e7-9ec5-a1d62d3f5bc2.png)
